### PR TITLE
fix: raise exceptions instead of returning error dicts

### DIFF
--- a/govbr_auth/controller.py
+++ b/govbr_auth/controller.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional
 from urllib.parse import urlparse
 
 from govbr_auth.core.config import GovBrConfig
+from govbr_auth.core.govbr import GovBrException, GovBrAuthenticationError
 from pydantic import BaseModel
 from govbr_auth import GovBrAuthorize
 from govbr_auth import GovBrIntegration
@@ -113,17 +114,25 @@ class GovBrConnector:
 
         @router.get(f"/{self.config.authorize_endpoint}")
         async def get_authorize_url():
-            return GovBrAuthorize(self.config).build_authorize_url()
+            try:
+                return GovBrAuthorize(self.config).build_authorize_url()
+            except GovBrException as e:
+                from fastapi import HTTPException
+                raise HTTPException(status_code=400, detail=str(e))
 
         @router.post(f"/{self.config.authenticate_endpoint}")
         async def govbr_callback(data: AuthenticationSchema, request: Request):
-            integration = GovBrIntegration(self.config)
-            result = await integration.async_exchange_code_for_token(data.code, data.state)
-            if self.on_auth_success:
-                result = self.on_auth_success(result, request)
-                if asyncio.iscoroutine(result):
-                    return await result
-            return result
+            try:
+                integration = GovBrIntegration(self.config)
+                result = await integration.async_exchange_code_for_token(data.code, data.state)
+                if self.on_auth_success:
+                    result = self.on_auth_success(result, request)
+                    if asyncio.iscoroutine(result):
+                        return await result
+                return result
+            except (GovBrException, GovBrAuthenticationError) as e:
+                from fastapi import HTTPException
+                raise HTTPException(status_code=401, detail=str(e))
 
         app.include_router(router)
 
@@ -224,8 +233,11 @@ class GovBrConnector:
 
         @bp.route(f'/{self.config.authorize_endpoint}', methods=['GET'])
         def get_authorize_url():
-            authorize = GovBrAuthorize(self.config)
-            return jsonify(authorize.build_authorize_url())
+            try:
+                authorize = GovBrAuthorize(self.config)
+                return jsonify(authorize.build_authorize_url())
+            except (GovBrException, GovBrAuthenticationError) as e:
+                return jsonify({"error": str(e)}), 400
 
         @bp.route(f'/{self.config.authenticate_endpoint}', methods=['POST'])
         def govbr_callback():
@@ -233,12 +245,15 @@ class GovBrConnector:
             state = request.args.get("state")
             if not code or not state:
                 return jsonify({"error": "Missing 'code' or 'state' parameter"}), 400
-            integration = GovBrIntegration(self.config)
-            result = integration.exchange_code_for_token_sync(code, state)
-            if self.on_auth_success:
-                return self.on_auth_success(result, request)
-            else:
-                return jsonify(result)
+            try:
+                integration = GovBrIntegration(self.config)
+                result = integration.exchange_code_for_token_sync(code, state)
+                if self.on_auth_success:
+                    return self.on_auth_success(result, request)
+                else:
+                    return jsonify(result)
+            except (GovBrException, GovBrAuthenticationError) as e:
+                return jsonify({"error": str(e)}), 401
 
         app.register_blueprint(bp)
 
@@ -331,7 +346,10 @@ class GovBrConnector:
 
             def get(self,
                     request):
-                return JsonResponse(GovBrAuthorize(self.config).build_authorize_url())
+                try:
+                    return JsonResponse(GovBrAuthorize(self.config).build_authorize_url())
+                except (GovBrException, GovBrAuthenticationError) as e:
+                    return JsonResponse({"error": str(e)}, status=400)
 
         class GovBrCallbackView(View):
             config = None
@@ -351,11 +369,14 @@ class GovBrConnector:
                 state = request.POST.get('state')
                 if not code or not state:
                     return JsonResponse({"error": "Missing 'code' or 'state' parameter"}, status=400)
-                result = asyncio.run(GovBrIntegration(self.config).async_exchange_code_for_token(code, state))
-                if self.on_auth_success:
-                    return self.on_auth_success(result, request)
-                else:
-                    return JsonResponse(result)
+                try:
+                    result = asyncio.run(GovBrIntegration(self.config).async_exchange_code_for_token(code, state))
+                    if self.on_auth_success:
+                        return self.on_auth_success(result, request)
+                    else:
+                        return JsonResponse(result)
+                except (GovBrException, GovBrAuthenticationError) as e:
+                    return JsonResponse({"error": str(e)}, status=401)
 
         urls_patterns = [
             path(self.config.authorize_endpoint, GovBrUrlView.as_view(), {'config': self.config},

--- a/govbr_auth/core/govbr.py
+++ b/govbr_auth/core/govbr.py
@@ -67,8 +67,8 @@ class GovBrAuthorize:
                 f"&code_challenge_method={self.config.code_challenge_method}"
             )
             return {"url": url}
-        except Exception as e:
-            raise GovBrException(f"Failed to build authorize URL: {str(e)}")
+        except (ValueError, KeyError, AttributeError) as e:
+            raise GovBrException(f"Falha ao gerar URL de autorização: {str(e)}")
 
     def build_authorize_url_sync(self) -> dict:
         return self.build_authorize_url()
@@ -119,11 +119,11 @@ class GovBrIntegration:
                                  code: str,
                                  state: str):
         if not self.config.client_id or not self.config.client_secret:
-            raise GovBrException("client_id and client_secret are required")
+            raise GovBrException("client_id e client_secret são obrigatórios")
 
         code_verifier = self.__decrypt_code_verifier(state)
         if code_verifier is None:
-            raise GovBrAuthenticationError("Invalid verification code")
+            raise GovBrAuthenticationError("Código de verificação inválido")
 
         data = {
             "grant_type":    "authorization_code",

--- a/govbr_auth/core/govbr.py
+++ b/govbr_auth/core/govbr.py
@@ -13,7 +13,7 @@ __all__ = ["GovBrAuthorize", "GovBrIntegration",
            "GovBrException", "GovBrAuthenticationError"]
 
 
-# excpetions
+# exceptions
 class GovBrException(Exception):
     """
     Exceção personalizada para erros relacionados ao Gov.br.
@@ -43,6 +43,15 @@ class GovBrAuthorize:
         return encrypted_verifier, code_challenge
 
     def build_authorize_url(self) -> dict:
+        """
+        Build the Gov.br authorization URL with PKCE parameters.
+
+        Returns:
+            Dict with the authorization URL.
+
+        Raises:
+            GovBrException: If URL generation fails.
+        """
         try:
             encrypted_verifier, code_challenge = self.__generate_codes()
             nonce = secrets.token_urlsafe(32)
@@ -59,7 +68,7 @@ class GovBrAuthorize:
             )
             return {"url": url}
         except Exception as e:
-            return {"error": f"Failed to build authorize URL: {str(e)}"}
+            raise GovBrException(f"Failed to build authorize URL: {str(e)}")
 
     def build_authorize_url_sync(self) -> dict:
         return self.build_authorize_url()
@@ -110,11 +119,11 @@ class GovBrIntegration:
                                  code: str,
                                  state: str):
         if not self.config.client_id or not self.config.client_secret:
-            return {"error": "Necessário informar client_id e client_secret"}
+            raise GovBrException("client_id and client_secret are required")
 
         code_verifier = self.__decrypt_code_verifier(state)
         if code_verifier is None:
-            return {"error": "Código de verificação inválido"}
+            raise GovBrAuthenticationError("Invalid verification code")
 
         data = {
             "grant_type":    "authorization_code",

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,124 @@
+"""
+Testes para validar tratamento de erro nos endpoints.
+Cobre cenários onde exceções são lançadas no core e convertidas para HTTP.
+"""
+
+import pytest
+from unittest.mock import patch, AsyncMock
+from httpx import AsyncClient, ASGITransport
+from fastapi import FastAPI
+from flask import Flask
+from cryptography.fernet import Fernet
+
+from govbr_auth.controller import GovBrConnector
+from govbr_auth.core.config import GovBrConfig
+from govbr_auth.core.govbr import GovBrException, GovBrAuthenticationError
+
+
+@pytest.fixture
+def valid_fernet_key():
+    """Gera uma chave Fernet válida para testes"""
+    return Fernet.generate_key().decode('utf-8')
+
+
+@pytest.fixture
+def fastapi_app(valid_fernet_key):
+    config = GovBrConfig(
+        client_id="dummy_id",
+        client_secret="dummy_secret",
+        govbr_auth_url="https://localhost/authorize",
+        govbr_token_url="https://localhost/token",
+        redirect_uri="https://localhost/callback",
+        cript_verifier_secret=valid_fernet_key,
+    )
+    app = FastAPI()
+    controller = GovBrConnector(config)
+    controller.init_fastapi(app)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_fastapi_post_authenticate_with_authentication_error(fastapi_app):
+    """Testa /authenticate quando erro de autenticação é lançado → HTTP 401"""
+    with patch(
+        "govbr_auth.core.govbr.GovBrIntegration.async_exchange_code_for_token",
+        new_callable=AsyncMock,
+        side_effect=GovBrAuthenticationError("Código de verificação inválido")
+    ):
+        transport = ASGITransport(app=fastapi_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                "/auth/govbr/authenticate",
+                json={"code": "invalid_code", "state": "invalid_state"}
+            )
+            assert response.status_code == 401
+            assert "detail" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_fastapi_post_authenticate_with_govbr_exception(fastapi_app):
+    """Testa /authenticate quando GovBrException é lançada → HTTP 401"""
+    with patch(
+        "govbr_auth.core.govbr.GovBrIntegration.async_exchange_code_for_token",
+        new_callable=AsyncMock,
+        side_effect=GovBrException("client_id e client_secret são obrigatórios")
+    ):
+        transport = ASGITransport(app=fastapi_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.post(
+                "/auth/govbr/authenticate",
+                json={"code": "code", "state": "state"}
+            )
+            assert response.status_code == 401
+            assert "detail" in response.json()
+
+
+# ============================================================================
+# FLASK TESTS
+# ============================================================================
+
+@pytest.fixture
+def flask_app(valid_fernet_key):
+    config = GovBrConfig(
+        client_id="dummy_id",
+        client_secret="dummy_secret",
+        govbr_auth_url="https://localhost/authorize",
+        govbr_token_url="https://localhost/token",
+        redirect_uri="https://localhost/callback",
+        cript_verifier_secret=valid_fernet_key,
+    )
+    app = Flask(__name__)
+    controller = GovBrConnector(config)
+    controller.init_flask(app)
+    app.testing = True
+    return app.test_client()
+
+
+def test_flask_post_authenticate_with_authentication_error(flask_app):
+    """Testa /authenticate com erro de autenticação → HTTP 401"""
+    with patch(
+        "govbr_auth.core.govbr.GovBrIntegration.exchange_code_for_token_sync",
+        side_effect=GovBrAuthenticationError("Código de verificação inválido")
+    ):
+        response = flask_app.post("/auth/govbr/authenticate?code=invalid&state=invalid")
+        assert response.status_code == 401
+        assert b"error" in response.data
+
+
+def test_flask_post_authenticate_with_govbr_exception(flask_app):
+    """Testa /authenticate com GovBrException → HTTP 401"""
+    with patch(
+        "govbr_auth.core.govbr.GovBrIntegration.exchange_code_for_token_sync",
+        side_effect=GovBrException("client_id e client_secret são obrigatórios")
+    ):
+        response = flask_app.post("/auth/govbr/authenticate?code=code&state=state")
+        assert response.status_code == 401
+        assert b"error" in response.data
+
+
+def test_flask_get_authorize_url_success(flask_app):
+    """Testa /authorize sucesso → HTTP 200 com URL"""
+    response = flask_app.get("/auth/govbr/authorize")
+    assert response.status_code == 200
+    assert b"url" in response.data or b"error" in response.data
+

--- a/tests/test_fake_auto_integration.py
+++ b/tests/test_fake_auto_integration.py
@@ -14,7 +14,7 @@ from govbr_auth import GovBrConfig, GovBrConnector, create_default_fake_users
 @pytest.fixture
 def valid_cript_secret():
     """Gera uma chave Fernet válida para testes"""
-    return base64.urlsafe_b64encode(Fernet.generate_key()).decode('utf-8')[:44]
+    return Fernet.generate_key().decode('utf-8')
 
 
 class TestFakeAutoIntegration:


### PR DESCRIPTION
## Summary
- Fix `__make_request_for_token()` which returned a dict on error but callers unpacked as tuple `(data, headers)`, causing `ValueError: too many values to unpack`
- Fix `build_authorize_url()` which returned errors as HTTP 200 JSON, masking failures from callers
- Both now raise `GovBrException`/`GovBrAuthenticationError` consistently
- Fix `excpetions` -> `exceptions` typo

## Test plan
- [ ] Verify that missing `client_id`/`client_secret` raises `GovBrException`
- [ ] Verify that invalid state/code_verifier raises `GovBrAuthenticationError`
- [ ] Verify that `build_authorize_url` raises on config errors instead of returning 200